### PR TITLE
docs: fix license badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![PyPI](https://img.shields.io/pypi/v/x402-openai)](https://pypi.org/project/x402-openai/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue)](https://python.org)
 [![CI](https://github.com/qntx/x402-openai-python/actions/workflows/python.yml/badge.svg)](https://github.com/qntx/x402-openai-python/actions)
-[![License](https://img.shields.io/badge/license-MIT%20%7C%20Apache--2.0-green)](LICENSE-MIT)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 </div>
 


### PR DESCRIPTION
# Description

Fix the incorrect license badge and broken license link in `README.md`.

The badge currently displays `MIT | Apache-2.0` and links to the non-existent `LICENSE-MIT` file. This PR updates the badge to display `MIT` and link to the existing `LICENSE` file.

## Changes

- Change the license badge from `MIT | Apache-2.0` to `MIT`
- Update the badge link from `LICENSE-MIT` to `LICENSE`
- Leave all other files and README content unchanged

Closes #<28>